### PR TITLE
Fix input focus on Android

### DIFF
--- a/frente.html
+++ b/frente.html
@@ -23,7 +23,7 @@
   </div>
 
   <!----- (opcional) input pra você digitar a leitura em kana ----->
-  <input  id="reading-input"  placeholder="読み仮名">
+  <input type="text" id="reading-input" placeholder="読み仮名">
   <button id="check-button">Check</button>
   <div    id="result"></div>
 
@@ -84,13 +84,13 @@
 
     document.getElementById('check-button').addEventListener('click', checkReading);
 
-    // Focus automático no input ao carregar
-    document.getElementById('reading-input').addEventListener('focus', function() {
-        window.scrollTo(0, this.getBoundingClientRect().top + window.scrollY);
-    });
-    window.addEventListener('load', function() {
-        document.getElementById('reading-input').focus();
-    });
+    // Ajuste de foco para navegadores que perdem o teclado no Android
+    var readingInput = document.getElementById('reading-input');
+    if (readingInput) {
+        readingInput.addEventListener('focus', function() {
+            window.scrollTo(0, this.getBoundingClientRect().top + window.scrollY);
+        });
+    }
 </script>
 <!--###MIGAKU JAPANESE SUPPORT JS STARTS###-->
 <script>

--- a/verso.html
+++ b/verso.html
@@ -101,10 +101,13 @@
 
     document.getElementById('check-button').addEventListener('click', checkReading);
 
-    // Focus automático no input ao carregar
-    document.getElementById('reading-input').addEventListener('focus', function() {
-        window.scrollTo(0, this.getBoundingClientRect().top + window.scrollY);
-    });
+    // Ajuste de foco para navegadores que perdem o teclado no Android
+    var readingInput = document.getElementById('reading-input');
+    if (readingInput) {
+        readingInput.addEventListener('focus', function() {
+            window.scrollTo(0, this.getBoundingClientRect().top + window.scrollY);
+        });
+    }
 </script>
 <!--###MIGAKU JAPANESE SUPPORT JS STARTS###-->
 <script>


### PR DESCRIPTION
## Summary
- add `type="text"` to the input field
- remove JS auto-focus and add null check
- handle focus safely in back template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684efb33f578832291ee0b386826f491